### PR TITLE
Add progress bar that tracks finished relaxations

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -4,6 +4,7 @@ dependencies:
 - requests=2.31.0
 - responses=0.23.2
 - tenacity=8.2.3
+- tqdm=4.66.1
 - pip:
   - dataclasses-json==0.6.0
 name: ocpapi

--- a/ocpapi/workflows/log.py
+++ b/ocpapi/workflows/log.py
@@ -1,0 +1,3 @@
+import logging
+
+log = logging.getLogger("ocpapi")


### PR DESCRIPTION
Uses tqdm to manage a progress bar tracking the status of all relaxations.

Example with logging disabled:

![Screenshot 2023-10-04 at 9 07 18 AM](https://github.com/Open-Catalyst-Project/ocpapi/assets/59006240/a34dd86d-60c2-4d97-982c-023bdf76441b)


Example with logging enabled:

![Screenshot 2023-10-04 at 9 02 53 AM](https://github.com/Open-Catalyst-Project/ocpapi/assets/59006240/c294a383-4344-48bc-a5f7-f8026d172197)


## Tests

```
python -m unittest
..................................................
----------------------------------------------------------------------
Ran 59 tests in 102.477s

OK
```