### PR TITLE
Do not flatten relaxation results across slabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,20 @@ This example adds the `slab_filter` field, which takes a function that selects o
 
 **Results should be saved whenever possible in order to avoid expensive recomputation.**
 
-Assuming `results` was generated with the `find_adsorbate_binding_sites` method used above, it contains a list of `AdsorbateSlabRelaxation` objects. Those results can be saved to file with:
+Assuming `results` was generated with the `find_adsorbate_binding_sites` method used above, it is an `AdsorbateBindingSites` object. This can be saved to file with:
 
 ```python
-from ocpapi import AdsorbateSlabRelaxation
-
 with open("results.json", "w") as f:
-    f.write(AdsorbateSlabRelaxation.schema().dumps(results, many=True))
+    f.write(results.to_json())
 ```
 
-Similarly, results can be read back from file to a list of `AdsorbateSlabRelaxation` objects with:
+Similarly, results can be read back from file to an `AdsorbateBindingSites` object with:
 
 ```python
-from ocpapi import AdsorbateSlabRelaxation
+from ocpapi import AdsorbateBindingSites
 
 with open("results.json", "r") as f:
-    results = AdsorbateSlabRelaxation.schema().loads(f.read(), many=True)
+    results = AdsorbateBindingSites.from_json(f.read())
 ```
 
 ## Advanced usage

--- a/ocpapi/client/models.py
+++ b/ocpapi/client/models.py
@@ -12,8 +12,8 @@ class _DataModel:
     Base class for all data models.
 
     Attributes:
-        other: Fields that may have been added to the API that all not yet
-            supported explicitly in this class.
+        other_fields: Fields that may have been added to the API that all
+            not yet supported explicitly in this class.
     """
 
     other_fields: CatchAll

--- a/ocpapi/workflows/__init__.py
+++ b/ocpapi/workflows/__init__.py
@@ -1,5 +1,6 @@
 from .adsorbates import (  # noqa
-    AdsorbateSlabRelaxation,
+    AdsorbateBindingSites,
+    AdsorbateSlabRelaxations,
     Lifetime,
     UnsupportedAdsorbateException,
     UnsupportedBulkException,

--- a/tests/integration/workflows/test_adsorbates.py
+++ b/tests/integration/workflows/test_adsorbates.py
@@ -101,5 +101,6 @@ class TestAdsorbates(IsolatedAsyncioTestCase):
                 lifetime=Lifetime.DELETE,
             )
 
-            self.assertEqual(1, len(results))
-            self.assertEqual(Status.SUCCESS, results[0].status)
+            self.assertEqual(1, len(results.slabs))
+            self.assertEqual(1, len(results.slabs[0].configs))
+            self.assertEqual(Status.SUCCESS, results.slabs[0].configs[0].status)


### PR DESCRIPTION
Previously, a call to `find_adsorbate_binding_sites` returned a list of `AdsorbateBindingSites` objects. Each contained everything about the binding site and relaxation - the model that was used, the bulk material, the slab, the final energy, positions, etc. 

This adds a couple layers of dataclasses to reduce duplication of information and group related results (like all relaxations on the same slab). Now `find_adsorbate_binding_sites` returns a `AdsorbateBindingSites` object, which contains the model, bulk, adsorbate, and list of slabs. Each slab is a  `AdsorbateSlabRelaxations` object, which contains the slab itself and the results of relaxations of all adsorbate placements (this lowest level object with relaxation results of a single placement is effectively what was returned from `find_adsorbate_binding_sites` before, with all fields removed that are now in the higher level classes).

## Tests

```
python -m unittest                    
..................................................                                                                                                                                              
----------------------------------------------------------------------
Ran 59 tests in 102.461s

OK
```