### PR TITLE
Check allowed models against server side list

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ urls = [
 ### Changing the model type
 
 The API currently supports two models:
-* `GEMNET_OC_BASE_S2EF_ALL_MD`: https://arxiv.org/abs/2204.02782
-* `EQUIFORMER_V2_31M_S2EF_ALL_MD` (default): https://arxiv.org/abs/2306.12059
+* `equiformer_v2_31M_s2ef_all_md` (default): https://arxiv.org/abs/2306.12059
+* `gemnet_oc_base_s2ef_all_md`: https://arxiv.org/abs/2204.02782
 
 A specific model type can be requested with:
 ```python
-from ocpapi import find_adsorbate_binding_sites, Model
+from ocpapi import find_adsorbate_binding_sites
 
 results = await find_adsorbate_binding_sites(
     adsorbate="*OH",
     bulk="mp-126",
-    model=Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+    model="gemnet_oc_base_s2ef_all_md",
 )
 ```
 

--- a/ocpapi/client/__init__.py
+++ b/ocpapi/client/__init__.py
@@ -15,6 +15,7 @@ from .models import (  # noqa
     Bulk,
     Bulks,
     Model,
+    Models,
     Slab,
     SlabMetadata,
     Slabs,

--- a/ocpapi/client/client.py
+++ b/ocpapi/client/client.py
@@ -14,7 +14,7 @@ from .models import (
     Atoms,
     Bulk,
     Bulks,
-    Model,
+    Models,
     Slab,
     Slabs,
 )
@@ -104,6 +104,27 @@ class Client:
         """
         return self._host
 
+    async def get_models(self) -> Models:
+        """
+        Fetch the list of models that are supported in the API.
+
+        Raises:
+            RateLimitExceededException if the call was rejected because a
+                server side rate limit was breached.
+            NonRetryableRequestException if the call was rejected and a retry
+                is not expected to succeed.
+            RequestException for all other errors when making the request; it
+                is possible, though not guaranteed, that a retry could succeed.
+
+        Returns:
+            Models
+        """
+        response: str = await self._run_request(
+            path="ocp/models",
+            method="GET",
+        )
+        return Models.from_json(response)
+
     async def get_bulks(self) -> Bulks:
         """
         Fetch the list of bulk materials that are supported in the API.
@@ -114,7 +135,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             Bulks
@@ -135,7 +156,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             Adsorbates
@@ -160,7 +181,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             Slabs
@@ -193,7 +214,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             AdsorbateSlabConfigs
@@ -217,7 +238,7 @@ class Client:
         adsorbate_configs: List[Atoms],
         bulk: Bulk,
         slab: Slab,
-        model: Model,
+        model: str,
         ephemeral: bool = False,
     ) -> AdsorbateSlabRelaxationsSystem:
         """
@@ -246,7 +267,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             AdsorbateSlabRelaxationsSystem
@@ -260,7 +281,7 @@ class Client:
                     "adsorbate_configs": [a.to_dict() for a in adsorbate_configs],
                     "bulk": bulk.to_dict(),
                     "slab": slab.to_dict(),
-                    "model": str(model),
+                    "model": model,
                     "ephemeral": ephemeral,
                 }
             ),
@@ -283,7 +304,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             AdsorbateSlabRelaxationsRequest
@@ -316,7 +337,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             AdsorbateSlabRelaxationsResults
@@ -346,7 +367,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
         """
         await self._run_request(
             path=f"ocp/adsorbate-slab-relaxations/{system_id}",
@@ -368,7 +389,7 @@ class Client:
             NonRetryableRequestException if the call was rejected and a retry
                 is not expected to succeed.
             RequestException for all other errors when making the request; it
-                possible, though not guaranteed, that a retry could succeed.
+                is possible, though not guaranteed, that a retry could succeed.
 
         Returns:
             The response body from the request as a string.

--- a/ocpapi/client/models.py
+++ b/ocpapi/client/models.py
@@ -21,6 +21,32 @@ class _DataModel:
 
 @dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
+class Model(_DataModel):
+    """
+    Stores information about a single model supported in the API.
+
+    Attributes:
+        id: The ID of the model.
+    """
+
+    id: str
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class Models(_DataModel):
+    """
+    Stores the response from a request for models supported in the API.
+
+    Attributes:
+        models: The list of models that are supported.
+    """
+
+    models: List[Model]
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
 class Bulk(_DataModel):
     """
     Stores information about a single bulk material.
@@ -198,22 +224,6 @@ class AdsorbateSlabRelaxationsSystem(_DataModel):
     config_ids: List[int]
 
 
-class Model(Enum):
-    """
-    ML model that can be used in adsorbate-slab relaxations.
-
-    Attributes:
-        GEMNET_OC_BASE_S2EF_ALL_MD: https://arxiv.org/abs/2204.02782
-        EQUIFORMER_V2_31M_S2EF_ALL_MD: https://arxiv.org/abs/2306.12059
-    """
-
-    GEMNET_OC_BASE_S2EF_ALL_MD = "gemnet_oc_base_s2ef_all_md"
-    EQUIFORMER_V2_31M_S2EF_ALL_MD = "equiformer_v2_31M_s2ef_all_md"
-
-    def __str__(self) -> str:
-        return self.value
-
-
 @dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
 class AdsorbateSlabRelaxationsRequest(_DataModel):
@@ -237,7 +247,7 @@ class AdsorbateSlabRelaxationsRequest(_DataModel):
     adsorbate_configs: List[Atoms]
     bulk: Bulk
     slab: Slab
-    model: Model
+    model: str
     # Omit from serialization when None
     ephemeral: Optional[bool] = field(
         default=None,

--- a/ocpapi/workflows/__init__.py
+++ b/ocpapi/workflows/__init__.py
@@ -4,6 +4,7 @@ from .adsorbates import (  # noqa
     Lifetime,
     UnsupportedAdsorbateException,
     UnsupportedBulkException,
+    UnsupportedModelException,
     find_adsorbate_binding_sites,
     get_adsorbate_slab_relaxation_results,
     keep_slabs_with_miller_indices,

--- a/tests/integration/client/test_client.py
+++ b/tests/integration/client/test_client.py
@@ -42,6 +42,16 @@ class TestClient(IsolatedAsyncioTestCase):
     )
     KNOWN_SYSTEM_ID: str = "f9eacd8f-748c-41dd-ae43-f263dd36d735"
 
+    async def test_get_models(self) -> None:
+        # Make sure that at least one of the known models is in the response
+
+        response = await self.CLIENT.get_models()
+
+        self.assertIn(
+            Model(id="equiformer_v2_31M_s2ef_all_md"),
+            response.models,
+        )
+
     async def test_get_bulks(self) -> None:
         # Make sure that at least one of the expected bulks is in the response
 
@@ -263,7 +273,7 @@ class TestClient(IsolatedAsyncioTestCase):
                     top=True,
                 ),
             ),
-            model=Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+            model="gemnet_oc_base_s2ef_all_md",
             ephemeral=True,
         )
 
@@ -368,7 +378,7 @@ class TestClient(IsolatedAsyncioTestCase):
                     top=True,
                 ),
             ),
-            model=Model.EQUIFORMER_V2_31M_S2EF_ALL_MD,
+            model="equiformer_v2_31M_s2ef_all_md",
             ephemeral=True,
         )
 

--- a/tests/integration/workflows/test_adsorbates.py
+++ b/tests/integration/workflows/test_adsorbates.py
@@ -4,7 +4,7 @@ from unittest import IsolatedAsyncioTestCase, mock
 
 import requests
 
-from ocpapi.client import Atoms, Client, Model, Status
+from ocpapi.client import Atoms, Client, Status
 from ocpapi.workflows import (
     Lifetime,
     find_adsorbate_binding_sites,
@@ -95,7 +95,7 @@ class TestAdsorbates(IsolatedAsyncioTestCase):
             results = await find_adsorbate_binding_sites(
                 adsorbate="*O",
                 bulk="mp-30",
-                model=Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+                model="gemnet_oc_base_s2ef_all_md",
                 slab_filter=keep_slabs_with_miller_indices([(1, 1, 1)]),
                 client=self.CLIENT,
                 # Since this is a test, delete the relaxations from the server

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -17,6 +17,7 @@ from ocpapi.client import (
     Bulks,
     Client,
     Model,
+    Models,
     NonRetryableRequestException,
     RateLimitExceededException,
     RequestException,
@@ -223,6 +224,32 @@ class TestClient(IsolatedAsyncioTestCase):
     def test_host(self) -> None:
         client = Client(host="test-host")
         self.assertEqual("test-host", client.host)
+
+    async def test_get_models(self) -> None:
+        await self._run_common_tests_against_route(
+            method="GET",
+            route="ocp/models",
+            client_method_name="get_models",
+            successful_response_code=200,
+            successful_response_body="""
+{
+    "models": [
+        {
+            "id": "model_1"
+        },
+        {
+            "id": "model_2"
+        }
+    ]
+}
+""",
+            successful_response_object=Models(
+                models=[
+                    Model(id="model_1"),
+                    Model(id="model_2"),
+                ]
+            ),
+        )
 
     async def test_get_bulks(self) -> None:
         await self._run_common_tests_against_route(
@@ -514,7 +541,7 @@ class TestClient(IsolatedAsyncioTestCase):
                         top=False,
                     ),
                 ),
-                "model": Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+                "model": "test_model",
                 "ephemeral": True,
             },
             expected_request_body={
@@ -548,7 +575,7 @@ class TestClient(IsolatedAsyncioTestCase):
                         "top": False,
                     },
                 },
-                "model": "gemnet_oc_base_s2ef_all_md",
+                "model": "test_model",
                 "ephemeral": True,
             },
             successful_response_code=200,
@@ -603,7 +630,7 @@ class TestClient(IsolatedAsyncioTestCase):
             "top": false
         }
     },
-    "model": "gemnet_oc_base_s2ef_all_md"
+    "model": "test_model"
 }
 """,
             successful_response_object=AdsorbateSlabRelaxationsRequest(
@@ -637,7 +664,7 @@ class TestClient(IsolatedAsyncioTestCase):
                         top=False,
                     ),
                 ),
-                model=Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+                model="test_model",
             ),
         )
 

--- a/tests/unit/client/test_models.py
+++ b/tests/unit/client/test_models.py
@@ -29,6 +29,7 @@ from ocpapi.client import (
     Bulk,
     Bulks,
     Model,
+    Models,
     Slab,
     SlabMetadata,
     Slabs,
@@ -127,6 +128,54 @@ class ModelTestWrapper:
             comparing the generated built-in types.
             """
             self.assertEqual(json.loads(first), json.loads(second))
+
+
+class TestModel(ModelTestWrapper.ModelTest[Model]):
+    """
+    Serde tests for the Model data model.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(
+            obj=Model(
+                id="model_id",
+                other_fields={"extra_field": "extra_value"},
+            ),
+            obj_json="""
+{
+    "id": "model_id",
+    "extra_field": "extra_value"
+}
+""",
+            *args,
+            **kwargs,
+        )
+
+
+class TestModels(ModelTestWrapper.ModelTest[Models]):
+    """
+    Serde tests for the Models data model.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(
+            obj=Models(
+                models=[Model(id="model_id")],
+                other_fields={"extra_field": "extra_value"},
+            ),
+            obj_json="""
+{
+    "models": [
+        {
+            "id": "model_id"
+        }
+    ],
+    "extra_field": "extra_value"
+}
+""",
+            *args,
+            **kwargs,
+        )
 
 
 class TestBulk(ModelTestWrapper.ModelTest[Bulk]):
@@ -549,7 +598,7 @@ class TestAdsorbateSlabRelaxationsRequest(
                         other_fields={"extra_meta_field": "extra_meta_value"},
                     ),
                 ),
-                model=Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+                model="test_model",
                 ephemeral=True,
                 adsorbate_reaction="A + B -> C",
                 other_fields={"extra_field": "extra_value"},
@@ -590,7 +639,7 @@ class TestAdsorbateSlabRelaxationsRequest(
             "extra_meta_field": "extra_meta_value"
         }
     },
-    "model": "gemnet_oc_base_s2ef_all_md",
+    "model": "test_model",
     "ephemeral": true,
     "adsorbate_reaction": "A + B -> C",
     "extra_field": "extra_value"
@@ -642,7 +691,7 @@ class TestAdsorbateSlabRelaxationsRequest_req_fields_only(
                         top=False,
                     ),
                 ),
-                model=Model.GEMNET_OC_BASE_S2EF_ALL_MD,
+                model="test_model",
             ),
             obj_json="""
 {
@@ -676,7 +725,7 @@ class TestAdsorbateSlabRelaxationsRequest_req_fields_only(
             "top": false
         }
     },
-    "model": "gemnet_oc_base_s2ef_all_md"
+    "model": "test_model"
 }
 """,
             *args,


### PR DESCRIPTION
Rather than use an enum for the supported models, accept a string. This ensures that users won't need to update the client version just because we add/remove models in the API. 

In the `find_adsorbate_binding_sites` workflow, check immediately whether the requested model is supported on the server. This ensures that we can raise quickly when invalid model names are requested, rather than waiting for the relaxation requests to be submitted (at which point they would be rejected for using an invalid model).