### PR TITLE
Prompt before submitting relaxations

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ results = await find_adsorbate_binding_sites(
 )
 ```
 
+### Skip relaxation approval prompts
+
+Calls to `find_adsorbate_binding_sites()` will, by default, show the user the relaxations that will be run and ask for approval before they are submitted. In order to run the relaxations automatically without manual approval, `skip_confirmation` can be added to the call. For example:
+```python
+from ocpapi import find_adsorbate_binding_sites
+
+results = await find_adsorbate_binding_sites(
+    adsorbate="*OH",
+    bulk="mp-126",
+    skip_confirmation=True,
+)
+```
+
 ### Converting to [ase.Atoms](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) objects
 
 **Important! The `to_ase_atoms()` method described below will fail with an import error if [ase](https://wiki.fysik.dtu.dk/ase) is not installed.**

--- a/ocpapi/workflows/__init__.py
+++ b/ocpapi/workflows/__init__.py
@@ -2,6 +2,7 @@ from .adsorbates import (  # noqa
     AdsorbateBindingSites,
     AdsorbateSlabRelaxations,
     Lifetime,
+    RelaxationsNotApproved,
     UnsupportedAdsorbateException,
     UnsupportedBulkException,
     UnsupportedModelException,


### PR DESCRIPTION
After adslabs are generated, but before the relaxations are started, prompt the user for approval to run them.

Tests cover new behavior, but as examples of the three possible outcomes...

Reject running relaxations:
```python
>>> results = await find_adsorbate_binding_sites(
...     adsorbate="*OH",
...     bulk="mp-126",
...     slab_filter=keep_slabs_with_miller_indices([(1,1,0),(1,1,1)]),
...     lifetime=Lifetime.DELETE,
... )
Generated 54 adsorbate configs on top (1, 1, 1) surface, shifted by 0.167
Generated 57 adsorbate configs on top (1, 1, 0) surface, shifted by 0.125
Continue with 111 relaxations? [y/n]: n
Traceback (most recent call last):
  File "/public/apps/anaconda3/2022.05/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/public/apps/anaconda3/2022.05/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "<console>", line 1, in <module>
  File "/private/home/kylemichel/src/github.com/open-catalyst-project/ocpapi/ocpapi/workflows/adsorbates.py", line 930, in find_adsorbate_binding_sites
    _prompt_for_approval(slabs_and_configs)
  File "/private/home/kylemichel/src/github.com/open-catalyst-project/ocpapi/ocpapi/workflows/adsorbates.py", line 834, in _prompt_for_approval
    raise RelaxationsNotApproved()
ocpapi.workflows.adsorbates.RelaxationsNotApproved: Relaxations not approved by user
```

Approve running relaxations:
```python
>>> results = await find_adsorbate_binding_sites(
...     adsorbate="*OH",
...     bulk="mp-126",
...     slab_filter=keep_slabs_with_miller_indices([(1,1,0),(1,1,1)]),
...     lifetime=Lifetime.DELETE,
... )
Generated 54 adsorbate configs on top (1, 1, 1) surface, shifted by 0.167
Generated 57 adsorbate configs on top (1, 1, 0) surface, shifted by 0.125
Continue with 111 relaxations? [y/n]: y
Finished relaxations:   0%|                                                    | 0/111 [00:04]
```

Skip approval check:
```python
>>> results = await find_adsorbate_binding_sites(
...     adsorbate="*OH",
...     bulk="mp-126",
...     slab_filter=keep_slabs_with_miller_indices([(1,1,0),(1,1,1)]),
...     lifetime=Lifetime.DELETE,
...     skip_confirmation=True,
... )
Finished relaxations:   0%|                                                    | 0/111 [00:04]
```